### PR TITLE
feat: add issuance methods and contract obj

### DIFF
--- a/ios/LwkRnModule.mm
+++ b/ios/LwkRnModule.mm
@@ -104,7 +104,12 @@
                       resolve: (RCTPromiseResolveBlock)resolve
                       reject:(RCTPromiseRejectBlock)reject
                       )
-    
+    RCT_EXTERN_METHOD(
+                      finalize:(nonnull NSString)wolletId
+                      psetId:(nonnull NSString)psetId
+                      resolve:(RCTPromiseResolveBlock)resolve
+                      reject:(RCTPromiseRejectBlock)reject
+                      )
     /** Transactions Methods */
     RCT_EXTERN_METHOD(
                       createTransaction: (nonnull NSString)string
@@ -139,12 +144,19 @@
                       resolve: (RCTPromiseResolveBlock)resolve
                       reject:(RCTPromiseRejectBlock)reject
                       )
+    
     RCT_EXTERN_METHOD(
-                    finalize:(nonnull NSString)wolletId
-                    psetId:(nonnull NSString)psetId
-                    resolve:(RCTPromiseResolveBlock)resolve
-                    reject:(RCTPromiseRejectBlock)reject
-    )
+                      issuanceAsset: (nonnull NSString)id
+                      index: (nonnull NSNumber)index
+                      resolve: (RCTPromiseResolveBlock)resolve
+                      reject:(RCTPromiseRejectBlock)reject
+                      )
+    RCT_EXTERN_METHOD(
+                      issuanceToken: (nonnull NSString)id
+                      index: (nonnull NSNumber)index
+                      resolve: (RCTPromiseResolveBlock)resolve
+                      reject:(RCTPromiseRejectBlock)reject
+                      )
     
     /** TxBuilder Methods */
     RCT_EXTERN_METHOD(
@@ -191,18 +203,59 @@
                       resolve: (RCTPromiseResolveBlock)resolve
                       reject:(RCTPromiseRejectBlock)reject
                       )
-    
     RCT_EXTERN_METHOD(
                       txBuilderFinish: (nonnull NSString)id
                       wolletId: (nonnull NSString)wolletId
                       resolve: (RCTPromiseResolveBlock)resolve
                       reject:(RCTPromiseRejectBlock)reject
                       )
+    RCT_EXTERN_METHOD(
+                      txBuilderFinish: (nonnull NSString)id
+                      wolletId: (nonnull NSString)wolletId
+                      resolve: (RCTPromiseResolveBlock)resolve
+                      reject:(RCTPromiseRejectBlock)reject
+                      )
+    RCT_EXTERN_METHOD(
+                      txBuilderIssueAsset: (nonnull NSString)id
+                      assetSats: (nonnull NSNumber)assetSats
+                      assetReceiver: (NSString)assetReceiver
+                      tokenSats: (nonnull NSNumber)tokenSats
+                      tokenReceiver: (NSString)tokenReceiver
+                      contractId: (NSString)contractId
+                      resolve: (RCTPromiseResolveBlock)resolve
+                      reject:(RCTPromiseRejectBlock)reject
+                      )
+    RCT_EXTERN_METHOD(
+                      txBuilderReissueAsset: (nonnull NSString)id
+                      assetToReissue: (nonnull NSString)assetToReissue
+                      satoshiToReissue: (nonnull NSNumber)satoshiToReissue
+                      assetReceiver: (NSString)assetReceiver
+                      issuanceTx: (NSString)issuanceTx
+                      resolve: (RCTPromiseResolveBlock)resolve
+                      reject:(RCTPromiseRejectBlock)reject
+                      )
     
+    /* Contract */
+    RCT_EXTERN_METHOD(
+                      createContract: (nonnull NSString)domain
+                      issuerPubkey: (nonnull NSString)issuerPubkey
+                      name: (nonnull NSString)name
+                      precision: (nonnull NSNumber)precision
+                      ticker: (nonnull NSString)ticker
+                      version: (nonnull NSNumber)version
+                      resolve: (RCTPromiseResolveBlock)resolve
+                      reject:(RCTPromiseRejectBlock)reject
+                      )
+    RCT_EXTERN_METHOD(
+                      contractAsString: (nonnull NSString)id
+                      resolve: (RCTPromiseResolveBlock)resolve
+                      reject:(RCTPromiseRejectBlock)reject
+                      )
+
     + (BOOL)requiresMainQueueSetup
     {
         return NO;
     }
-    
+
 @end
     

--- a/src/classes/NativeLoader.ts
+++ b/src/classes/NativeLoader.ts
@@ -50,6 +50,8 @@ export interface NativeLwk {
   // Pset
   psetAsString(psetId: string): string;
   psetExtractTx(psetId: string): string;
+  psetIssuanceAsset(id: string, index: number): string;
+  psetissuanceToken(id: string, index: number): string;
 
   // TxBuilder
   createTxBuilder(network: string): string;
@@ -65,6 +67,32 @@ export interface NativeLwk {
   txBuilderDrainLbtcWallet(id: string): null;
   txBuilderFeeRate(id: string, rate: number | null): null;
   txBuilderFinish(id: string, wolletId: string): string;
+  txBuilderIssueAsset(
+    id: string,
+    assetSats: number,
+    assetReceiver: string | null,
+    tokenSats: number,
+    tokenReceiver: string | null,
+    contract: string | null
+  ): null;
+  txBuilderReissueAsset(
+    id: string,
+    assetToReissue: string,
+    satoshiToReissue: number,
+    assetReceiver: string | null,
+    issuanceTx: string | null
+  ): null;
+
+  // Contract
+  createContract(
+    domain: string,
+    issuerPubkey: string,
+    name: string,
+    precision: number,
+    ticker: string,
+    version: number
+  ): string;
+  contractAsString(id: string): string;
 }
 
 export class NativeLoader {

--- a/src/classes/Pset.ts
+++ b/src/classes/Pset.ts
@@ -17,4 +17,12 @@ export class Pset extends NativeLoader {
   async asString(): Promise<string> {
     return this._lwk.psetAsString(this.id);
   }
+
+  async issuanceAsset(index: number): Promise<string> {
+    return this._lwk.psetIssuanceAsset(this.id, index);
+  }
+
+  async issuanceToken(index: number): Promise<string> {
+    return this._lwk.psetissuanceToken(this.id, index);
+  }
 }

--- a/src/classes/TxBuilder.ts
+++ b/src/classes/TxBuilder.ts
@@ -1,6 +1,8 @@
 import { NativeLoader } from './NativeLoader';
 import { Wollet } from './Wollet';
 import { Pset } from './Pset';
+import type { Contract } from '../lib/types';
+import { Transaction } from '../../lib/typescript/commonjs/src';
 
 export class TxBuilder extends NativeLoader {
   id: string = '';
@@ -46,5 +48,50 @@ export class TxBuilder extends NativeLoader {
   async finish(wollet: Wollet): Promise<Pset> {
     let psetId = await this._lwk.txBuilderFinish(this.id, wollet.id);
     return new Pset().from(psetId);
+  }
+
+  async issueAsset(
+    assetSats: number,
+    assetReceiver: string | null,
+    tokenSats: number,
+    tokenReceiver: string | null,
+    contract: Contract | null
+  ): Promise<null> {
+    let contractId =
+      contract == null
+        ? null
+        : this._lwk.createContract(
+            contract.domain,
+            contract.issuerPubkey,
+            contract.name,
+            contract.precision,
+            contract.ticker,
+            contract.version
+          );
+    return await this._lwk.txBuilderIssueAsset(
+      this.id,
+      assetSats,
+      assetReceiver,
+      tokenSats,
+      tokenReceiver,
+      contractId
+    );
+  }
+
+  async reissueAsset(
+    assetToReissue: string,
+    satoshiToReissue: number,
+    assetReceiver: string | null,
+    issuanceTx: Transaction | null
+  ): Promise<null> {
+    let transactionHex =
+      issuanceTx == null ? null : await issuanceTx?.asString();
+    return await this._lwk.txBuilderReissueAsset(
+      this.id,
+      assetToReissue,
+      satoshiToReissue,
+      assetReceiver,
+      transactionHex
+    );
   }
 }

--- a/src/classes/Wollet.ts
+++ b/src/classes/Wollet.ts
@@ -30,7 +30,7 @@ export class Wollet extends NativeLoader {
     return await this._lwk.getTransactions(this.id);
   }
 
-   async getAddress(addressNum: number = 0): Promise<Address> {
+  async getAddress(addressNum: number = 0): Promise<Address> {
     return await this._lwk.getAddress(this.id, addressNum);
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,12 @@ import { Pset } from './classes/Pset';
 import { Transaction } from './classes/Transaction';
 import { TxBuilder } from './classes/TxBuilder';
 import { Network, ClientNames } from './lib/enums';
-import { type Address, type WolletTx, type Balance } from './lib/types';
+import {
+  type Address,
+  type WolletTx,
+  type Balance,
+  type Contract,
+} from './lib/types';
 import { type ElectrumClientConfig } from './lib/interfaces';
 
 export {
@@ -20,6 +25,7 @@ export {
   TxBuilder,
   ClientNames,
   type Address,
+  type Contract,
   type WolletTx,
   type Balance,
   type ElectrumClientConfig,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,3 +20,12 @@ export type Address = {
   qr_code_text: string;
   script_pubkey: string;
 }
+
+export type Contract = {
+  domain: string;
+  issuerPubkey: string;
+  name: string;
+  precision: number;
+  ticker: string;
+  version: number;  
+}


### PR DESCRIPTION
- add `Contract` model and expose
- add pset: `psetIssuanceAsset` & `psetIssuanceToken`
- add txBuilder: `txBuilderIssueAsset` & `txBuilderIssueToken`
- fix annotation on android code