### PR TITLE
build: remove pod auto-install for react compatibility

### DIFF
--- a/example/react-native.config.js
+++ b/example/react-native.config.js
@@ -9,7 +9,6 @@ module.exports = {
     },
     ios: {
       sourceDir: 'ios',
-      automaticPodsInstallation: true,
     },
   }),
   dependencies: {


### PR DESCRIPTION
Pod fails to install using `npm example ios`. Comment out the pod autoinstallation and works.