### PR TITLE
fix: optional index on address generation

### DIFF
--- a/android/src/main/java/io/lwkrn/Utils.kt
+++ b/android/src/main/java/io/lwkrn/Utils.kt
@@ -35,8 +35,8 @@ fun getTransactionObject(transaction: WalletTx): MutableMap<String, Any?> {
   )
 }
 
-fun getAddressObject(address: Address): MutableMap<String, Any?> {
-  return mutableMapOf<String, Any?>(
+fun getAddressObject(address: Address): MutableMap<String, Any> {
+  return mutableMapOf<String, Any>(
     "description" to address.toString(),
     "is_blinded" to address.isBlinded(),
     "qr_code_text" to address.qrCodeText(),

--- a/ios/LwkRnModule.mm
+++ b/ios/LwkRnModule.mm
@@ -95,7 +95,7 @@
     
     RCT_EXTERN_METHOD(
                       getAddress: (nonnull NSString)wolletId
-                      index: (NSNumber)index
+                      index: (nullable NSString)index
                       resolve: (RCTPromiseResolveBlock)resolve
                       reject:(RCTPromiseRejectBlock)reject
                       )

--- a/ios/LwkRnModule.swift
+++ b/ios/LwkRnModule.swift
@@ -244,13 +244,14 @@ class LwkRnModule: NSObject {
     @objc
     func getAddress(_
                     wolletId: String,
-                    index: NSNumber? = nil,
+                    index: String? = nil,
                     resolve: RCTPromiseResolveBlock,
                     reject: RCTPromiseRejectBlock
     ) -> Void {
         do {
             let wollet = _wollets[wolletId]
-            let address = try wollet!.address(index: index?.uint32Value).address()
+            let index = index == nil ? nil : UInt32(index!, radix: 10)
+            let address = try wollet!.address(index: index).address()
             resolve(getAddressObject(address: address))
         } catch {
             reject("Wollet getAddress error", error.localizedDescription, error)


### PR DESCRIPTION
Fix address generation index parameter on iOS. React native doesn't support nullable NSNumber for iOS interface
https://github.com/facebook/react-native/issues/24250